### PR TITLE
Add JWT auth utilities and admin route protection

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,0 +1,17 @@
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError
+
+from app.core.auth import verify_token
+
+security = HTTPBearer()
+
+
+def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    if credentials is None:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    token = credentials.credentials
+    try:
+        return verify_token(token)
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,9 +1,10 @@
-﻿from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import List, Optional
 from app.db.session import SessionLocal
 from app.models.lawyer import Lawyer
 from app.schemas.lawyer import LawyerCreate, LawyerOut, LawyerUpdate
+from app.api.deps import get_current_user
 
 router = APIRouter()
 
@@ -19,7 +20,13 @@ def health():
     return {"status": "ok"}
 
 @router.post("/lawyers", response_model=LawyerOut)
-def create_lawyer(payload: LawyerCreate, db: Session = Depends(get_db)):
+def create_lawyer(
+    payload: LawyerCreate,
+    db: Session = Depends(get_db),
+    user: dict = Depends(get_current_user),
+):
+    if user.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Not authorized")
     item = Lawyer(
         full_name=payload.full_name,
         email=payload.email,
@@ -62,9 +69,15 @@ def list_lawyers(
         query = query.filter((Lawyer.full_name.ilike(like)) | (Lawyer.firm.ilike(like)) | (Lawyer.bio.ilike(like)))
     return query.offset(offset).limit(limit).all()
 
-
 @router.put("/lawyers/{lawyer_id}", response_model=LawyerOut)
-def update_lawyer(lawyer_id: int, payload: LawyerUpdate, db: Session = Depends(get_db)):
+def update_lawyer(
+    lawyer_id: int,
+    payload: LawyerUpdate,
+    db: Session = Depends(get_db),
+    user: dict = Depends(get_current_user),
+):
+    if user.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Not authorized")
     obj = db.query(Lawyer).get(lawyer_id)
     if not obj:
         raise HTTPException(status_code=404, detail="Lawyer not found")
@@ -77,4 +90,3 @@ def update_lawyer(lawyer_id: int, payload: LawyerUpdate, db: Session = Depends(g
         setattr(obj, campo, valor)
     db.commit(); db.refresh(obj)
     return obj
-

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -1,0 +1,22 @@
+from datetime import datetime, timedelta
+from typing import Optional, Dict, Any
+
+from jose import jwt, JWTError
+
+from app.core.config import JWT_SECRET
+
+ALGORITHM = "HS256"
+DEFAULT_EXPIRE_MINUTES = 60
+
+def create_access_token(data: Dict[str, Any], expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=DEFAULT_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, JWT_SECRET, algorithm=ALGORITHM)
+
+
+def verify_token(token: str) -> Dict[str, Any]:
+    try:
+        return jwt.decode(token, JWT_SECRET, algorithms=[ALGORITHM])
+    except JWTError as exc:
+        raise exc


### PR DESCRIPTION
## Summary
- add JWT creation and verification helpers
- add dependency for extracting current user from bearer token
- restrict lawyer create/update endpoints to admin users

## Testing
- `pytest -q`
- `python -m py_compile app/api/deps.py app/core/auth.py app/api/routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68b234df1e508326aa98d5d93b118a0a