### PR TITLE
Add centralized error handlers for HTTP and database errors

### DIFF
--- a/app/core/error_handlers.py
+++ b/app/core/error_handlers.py
@@ -1,0 +1,20 @@
+from fastapi import Request
+from fastapi.exceptions import HTTPException
+from fastapi.responses import JSONResponse
+from sqlalchemy.exc import SQLAlchemyError
+
+
+async def http_error_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    """Return JSON for HTTP exceptions."""
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"code": exc.status_code, "message": exc.detail},
+    )
+
+
+async def db_error_handler(request: Request, exc: SQLAlchemyError) -> JSONResponse:
+    """Return JSON for database errors."""
+    return JSONResponse(
+        status_code=500,
+        content={"code": 500, "message": "Database error"},
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,19 @@
-﻿from fastapi import FastAPI
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy.exc import SQLAlchemyError
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
 from app.api.routes import router
+from app.core.error_handlers import db_error_handler, http_error_handler
 from app.db.session import Base, engine
 
 # Crear tablas (SQLite); en Postgres luego usaremos Alembic
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Abogados API")
+
+app.add_exception_handler(StarletteHTTPException, http_error_handler)
+app.add_exception_handler(SQLAlchemyError, db_error_handler)
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- add error handlers for HTTP and database errors returning unified JSON format
- register handlers in main app

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b234e0c0e08326af18e1f58e28aef8