### PR TITLE
Add endpoint to retrieve lawyer by id

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -63,6 +63,13 @@ def list_lawyers(
     return query.offset(offset).limit(limit).all()
 
 
+@router.get("/lawyers/{lawyer_id}", response_model=LawyerOut)
+def get_lawyer(lawyer_id: int, db: Session = Depends(get_db)):
+    obj = db.query(Lawyer).get(lawyer_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Lawyer not found")
+    return obj
+
 @router.put("/lawyers/{lawyer_id}", response_model=LawyerOut)
 def update_lawyer(lawyer_id: int, payload: LawyerUpdate, db: Session = Depends(get_db)):
     obj = db.query(Lawyer).get(lawyer_id)


### PR DESCRIPTION
## Summary
- add API route to fetch a lawyer by its id and return 404 if missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b234e70d8c8326bdf0903d07741936